### PR TITLE
Workaround for TRIANGLE_STRIP Issues in sketch.js

### DIFF
--- a/challenges/CC_11_PerlinNoiseTerrain_p5.js/sketch.js
+++ b/challenges/CC_11_PerlinNoiseTerrain_p5.js/sketch.js
@@ -2,21 +2,18 @@
 // http://codingrainbow.com
 // http://patreon.com/codingrainbow
 // Code for: https://youtu.be/IKB1hWWedMk
+// edits by: Perry Taga
 
-var cols, rows;
-var scl = 20;
-var w = 1400;
-var h = 1000;
-
+var w = 720;  // dimensions
+var h = 500;
+var scl = 10; // size of triangles, increasing scl gnerally speeds up performance.
+var cols = w/scl;
+var rows = h/scl;
+var terrain;
 var flying = 0;
 
-var terrain;
-
-function setup() {
-  createCanvas(600, 600, WEBGL);
-  cols = w / scl;
-  rows = h/ scl;
-
+function setup() {  // create the canvas, and create a 2D array for mesh z values
+  createCanvas(w, h, WEBGL);
   terrain = [];
   for (var x = 0; x < cols; x++) {
     terrain[x] = [];
@@ -25,32 +22,37 @@ function setup() {
 
 function draw() {
 
-  flying -= 0.1;
-  var yoff = flying;
+  flying -= 0.1;  // movement rate
+  var yoff = flying;  // move z values along th y axis
   for (var y = 0; y < rows; y++) {
     var xoff = 0;
     for (var x = 0; x < cols; x++) {
-      terrain[x][y] = map(noise(xoff, yoff), 0, 1, -100, 100);
-      xoff += 0.2;
+      terrain[x][y] = map(noise(xoff, yoff), 0, 1, -75, 75);  // set z values for each (x,y) on the mesh
+      xoff += 0.1;
     }
-    yoff += 0.2;
+    yoff += 0.1;
   }
 
-
-  background(0);
-  translate(0, 50);
-  rotateX(-PI/3);
-  translate(-w/2, -h/2);
-  for (var y = 0; y < rows-1; y++) {
-    //beginShape(TRIANGLE_STRIP);
-    for (var x = 0; x < cols; x++) {
-      push();
-      translate(x*scl, y*scl, terrain[x][y]);
-      box(scl);
-      pop();
-      //vertex(x*scl, y*scl, terrain[x][y]);
-      //vertex(x*scl, (y+1)*scl, terrain[x][y+1]);
+  background(255);  // background: at the moment should not be 0, since line color cannot be changed
+  
+  translate(-(w/2), -(h/3), 0); // WEBGL sets (0,0) in the center of the canvas.
+  rotateX(-PI/3.25);  // creates 3D perspective, try different constants.
+  for(var y = 0; y < (rows-1); y++){  // x+1 and y+1 are indexed below, so both loops have offset.
+    for(var x = 0; x < (cols-1); x++){
+      beginShape(LINES);  
+      vertex((x*scl), (y*scl), terrain[x][y]);  // begin first side of triangle
+      vertex((x*scl), ((y+1)*scl), terrain[x][(y+1)]); // end first side of triangle, etc
+      vertex((x*scl), ((y+1)*scl), terrain[x][(y+1)]);
+      vertex(((x+1)*scl), ((y+1)*scl), terrain[(x+1)][(y+1)]);
+      vertex(((x+1)*scl), ((y+1)*scl), terrain[(x+1)][(y+1)]);
+      vertex((x*scl), (y*scl), terrain[x][y]);
+      endShape();
+      if(y == 0){  // draws the horizon line on the initial sawtooth
+        beginShape(LINES);
+        vertex((x*scl), (y*scl), terrain[x][y]);
+        vertex(((x+1)*scl), (y*scl), terrain[(x+1)][y]);
+        endShape();
+      }
     }
-    //endShape();
   }
 }


### PR DESCRIPTION
Draws the geometry using lines instead of boxes. Code has been commented to reflect this.

Line coloring doesn't seem to be working with WebGL canvases at the moment.
Performance testing has had various results on different machines. The generated graphics are much closer to the original tutorial, though.